### PR TITLE
Major update in plugin Trills

### DIFF
--- a/triller.qml
+++ b/triller.qml
@@ -577,7 +577,7 @@ MuseScore {
 
         // Row 7
         Label {
-            text: qsTr("Expansion:")
+            text: qsTr("Expressive expansion:")
             Layout.columnSpan:2
         }
         Canvas {
@@ -633,57 +633,12 @@ MuseScore {
                 }
                 ctx.stroke();
 
-                //write BPMs
-                //                      canvasStartExp.text = start;
-                //                      canvasStartExp.topPadding = (start > end) ? (top + 2) : (top + length - canvasStartExp.contentHeight - 2);
-//                canvasEndExp.text = end;
-//                canvasEndExp.topPadding = (start > end) ? (top + length - canvasEndExp.contentHeight - 2): (top + 2);
-                //keep them inside the grid or is there enough room next to it?
-                //var longestBPMText = Math.max(canvasStartExp.contentWidth, canvasEndExp.contentWidth);
-                //                      if ((longestBPMText + 2 + 2) < left) {
-                //                            //outside
-                //                            //canvasStartExp.leftPadding = left - 2 - canvasStartExp.contentWidth;
-                //                            canvasEndExp.leftPadding = left - 2 - canvasEndExp.contentWidth;
-                //                      }
-                //                      else {
-                //                            //inside
-                //                            //canvasStartExp.leftPadding = left + 2;
-                //                            canvasEndExp.leftPadding = left + 2;
-                //                      }
+
             }
-            //                Label {
-            //                      id: canvasStartExp
-            //                      color: '#d8d8d8'
-            //                }
-//            Label {
-//                id: canvasEndExp
-//                color: '#d8d8d8'
-//            }
+
         } //end of Canvas
 
-        //          Label {
-        //                text: qsTr("Start expansion:")
-        //          }
-        //          TextField {
-        //                id: startExpValue
-        //                placeholderText: '50'
-        //                validator: DoubleValidator { bottom: 1;/* top: 512;*/ decimals: 1; notation: DoubleValidator.StandardNotation; }
-        //                implicitHeight: 24
-        //                onTextChanged: { canvas.requestPaint(); }
-        //          }
 
-//        Label {
-//            text: qsTr("End expansion:")
-//            Layout.rowSpan: 3
-//        }
-//        TextField {
-//            id: endExpValue
-//            placeholderText: '50'
-//            validator: DoubleValidator { bottom: 1;/* top: 512;*/ decimals: 1; notation: DoubleValidator.StandardNotation; }
-//            implicitHeight: 24
-//            Layout.rowSpan: 3
-//            onTextChanged: { canvas.requestPaint(); }
-//        }
         ComboBox {
             id: curveType
             model: ListModel {
@@ -709,9 +664,9 @@ MuseScore {
             id: midpointSlider
             Layout.fillWidth: true
 
-            minimumValue: 1
-            maximumValue: 99
-            value: 75.0
+            minimumValue: 25 //1
+            maximumValue: 75 //99 -> range reduced to make the centre less sensitive
+            value: 50.0
             stepSize: 0.1
 
             enabled: !curveType.isLinear


### PR DESCRIPTION
New changes implemented:

- Support for baroque and “non-baroque” (standard) trills. Baroque trills are defined by having the first note up. The non-baroque ones have the first note down. Solves #1
- Logarithmic expressive expansion implemented – flexible humanization in playback, which approximates the way trills are actually played. For this, use the curved expansion, set the slider to a midpoint value below 50% and get a logarithmically accelerating trill playback. This can be easily undone by running the plugin again setting the expansion mode to linear or the midpoint to 50%.
- 3/2-tones trill supported now. This is needed for the basic case of augmented-second trills. Only minor and major seconds were supported. Trills with diminished seconds are still not supported. In this case, the trill equals a tremolo, because it will alternate the note with an enharmonic version of itself. So, at least for 12TET, trills with diminished seconds are grammatically correct, but don't make semantic sense. Could still be implemented if there is demand, but let's wait for MuseScore 4.